### PR TITLE
Remove concurency flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   - vendor/bundle
 
 script:
-  - bundle exec kitchen test --concurrency
+  - bundle exec kitchen test
 
 notifications:
   disable: true


### PR DESCRIPTION
Mostly for testing purposes, - Travis fails randomly when destroying container.

@vinted/sre 