### PR TITLE
Specify cookbook name to search template in

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,7 @@ platforms:
 suites:
   - name: orchestrator-mysql
     run_list:
-      - recipe[orchestrator::orchestrator]
+      - recipe[orchestrator-test-mysql::default]
     verifier:
       inspec_tests:
         - test/integration/mysql

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group 'test' do
   cookbook 'orchestrator-test-sqlite', path: 'test/integration/cookbooks/orchestrator-test-sqlite'
+  cookbook 'orchestrator-test-mysql', path: 'test/integration/cookbooks/orchestrator-test-mysql'
 end

--- a/libraries/orchestrator.rb
+++ b/libraries/orchestrator.rb
@@ -186,6 +186,7 @@ class Chef
           mode 0o644
           variables root_pass: new_resource.mysql_root_password
           not_if { ::File.exist?('/root/.my.cnf') }
+          cookbook 'orchestrator'
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/vinted/chef-orchestrator/issues'
 source_url 'https://github.com/vinted/chef-orchestrator'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '0.1.0'
+version '0.1.1'
 
 supports 'redhat'
 supports 'centos'

--- a/test/integration/cookbooks/orchestrator-test-mysql/README.md
+++ b/test/integration/cookbooks/orchestrator-test-mysql/README.md
@@ -1,0 +1,1 @@
+# orchestrator-test-mysql

--- a/test/integration/cookbooks/orchestrator-test-mysql/metadata.rb
+++ b/test/integration/cookbooks/orchestrator-test-mysql/metadata.rb
@@ -1,0 +1,10 @@
+name 'orchestrator-test-mysql'
+maintainer 'Vinted SRE'
+maintainer_email 'sre@vinted.com'
+license 'MIT'
+description 'Installs/Configures github orchestrator'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+chef_version '>= 12.1' if respond_to?(:chef_version)
+
+depends 'orchestrator'

--- a/test/integration/cookbooks/orchestrator-test-mysql/recipes/default.rb
+++ b/test/integration/cookbooks/orchestrator-test-mysql/recipes/default.rb
@@ -1,0 +1,2 @@
+orchestrator_service 'default' do
+end


### PR DESCRIPTION
Fixes issue with cookbook:

```
Cookbook 'vinted-orchestrator' (0.1.0) does not contain a file at any of these locations:
templates/centos-7.5.1804/root_my_cnf.erb
templates/centos/root_my_cnf.erb
templates/default/root_my_cnf.erb
templates/root_my_cnf.erb
```